### PR TITLE
Remove audio_format parameter

### DIFF
--- a/src/audD.js
+++ b/src/audD.js
@@ -11,7 +11,6 @@ const audDMatcher = (() => {
     }
     form.append('method', 'recognize');
     form.append('file', context.mp3Blob);
-    form.append('audio_format', 'mp3');
 
     let url = `https://api.audd.io`;
 


### PR DESCRIPTION
Since the second version of the API, `audio_format` parameter is no longer needed.